### PR TITLE
Link to developer files when dependency is bundled

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "black-hole-stream": "0.0.1",
-    "busboy": "0.2.13"
+    "busboy": "0.2.14"
   },
   "devDependencies": {
     "co": "4.6.x",


### PR DESCRIPTION
update busboy dependency (fixes the following):
https://github.com/mscdex/busboy/issues/121